### PR TITLE
More accurately limit number of posts returned

### DIFF
--- a/redditapp.js
+++ b/redditapp.js
@@ -48,7 +48,7 @@ function loadSubreddits(subreddits, numPosts) {
 			return post2.data.score - post1.data.score;
 		});
 
-		for (var i = 0; i < posts.length; i++) {
+		for (var i = 0; i < posts.length && i < numPosts; i++) {
 			postList.appendChild(getPosts(posts[i].data));
 		}
 


### PR DESCRIPTION
Reddit's API seems to be returning the limit number you request plus whatever
pinned posts there are for that subreddit. This limits in the appending loop so
that it only lists the things that are most currently active in the subreddit
(may or may not omit pinned depending on their activity).

Closes #3 